### PR TITLE
add ReLU in Header Conv

### DIFF
--- a/models/centernet.py
+++ b/models/centernet.py
@@ -39,16 +39,19 @@ class CenterNet(nn.Module):
 
         self.cls_pred = nn.Sequential(
             Conv(256, 64, k=3, p=1),
+            nn.ReLU(),
             nn.Conv2d(64, self.num_classes, kernel_size=1)
         )
 
         self.txty_pred = nn.Sequential(
             Conv(256, 64, k=3, p=1),
+            nn.ReLU(),
             nn.Conv2d(64, 2, kernel_size=1)
         )
        
         self.twth_pred = nn.Sequential(
             Conv(256, 64, k=3, p=1),
+            nn.ReLU(),
             nn.Conv2d(64, 2, kernel_size=1)
         )
 


### PR DESCRIPTION
add ReLU in Header Conv

![image](https://user-images.githubusercontent.com/35001605/110226099-7ea70e80-7f2f-11eb-85af-e36bec39a872.png)

Original implementation includes ReLU() in Header.

In my experiments, It reported 75.73 mAP.

Your pre-trained model was trained without ReLU. If you want pretrained model with ReLU, I can share it for you.


